### PR TITLE
Add NumForm to a bunch of NumType=Ord words.  

### DIFF
--- a/en_pud-ud-test.conllu
+++ b/en_pud-ud-test.conllu
@@ -666,7 +666,7 @@
 6	for	for	SCONJ	IN	_	7	case	7:case	_
 7	cutting	cut	VERB	VBG	VerbForm=Ger	5	acl	5:acl:for	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
-9	first	first	ADJ	JJ	Degree=Pos|NumType=Ord	10	amod	10:amod	_
+9	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	10	amod	10:amod	_
 10	steel	steel	NOUN	NN	Number=Sing	7	obj	7:obj	_
 11	would	would	AUX	MD	VerbForm=Fin	12	aux	12:aux	_
 12	help	help	VERB	VB	VerbForm=Inf	3	ccomp	3:ccomp	_
@@ -791,7 +791,7 @@
 18	component	component	NOUN	NN	Number=Sing	15	obj	15:obj	_
 19	for	for	ADP	IN	_	25	case	25:case	_
 20	a	a	DET	DT	Definite=Ind|PronType=Art	25	det	25:det	_
-21	third	third	ADJ	JJ	Degree=Pos|NumType=Ord	23	amod	23:amod	SpaceAfter=No
+21	third	third	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	23	amod	23:amod	SpaceAfter=No
 22	-	-	PUNCT	HYPH	_	23	punct	23:punct	SpaceAfter=No
 23	party	party	NOUN	NN	Number=Sing	25	amod	25:amod	_
 24	power	power	NOUN	NN	Number=Sing	25	compound	25:compound	_
@@ -2117,7 +2117,7 @@
 5	invitation	invitation	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	to	to	ADP	IN	_	9	case	9:case	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
-8	45th	45th	ADJ	JJ	Degree=Pos|NumType=Ord	9	amod	9:amod	_
+8	45th	45th	ADJ	JJ	Degree=Pos|NumForm=Combi|NumType=Ord	9	amod	9:amod	_
 9	president	president	NOUN	NN	Number=Sing	3	obl	3:obl:to	_
 10	of	of	ADP	IN	_	13	case	13:case	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
@@ -2438,7 +2438,7 @@
 7	end	end	NOUN	NN	Number=Sing	4	obl	4:obl:until	_
 8	of	of	ADP	IN	_	11	case	11:case	_
 9	his	he	PRON	PRP$	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	11	nmod:poss	11:nmod:poss	_
-10	first	first	ADJ	JJ	Degree=Pos|NumType=Ord	11	amod	11:amod	_
+10	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	11	amod	11:amod	_
 11	term	term	NOUN	NN	Number=Sing	7	nmod	7:nmod:of	_
 12	to	to	PART	TO	_	13	mark	13:mark	_
 13	use	use	VERB	VB	VerbForm=Inf	4	acl	4:acl:to	_
@@ -2522,7 +2522,7 @@
 7	,	,	PUNCT	,	_	3	punct	3:punct	_
 8	made	make	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
 9	her	she	PRON	PRP$	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	11	nmod:poss	11:nmod:poss	_
-10	first	first	ADJ	JJ	Degree=Pos|NumType=Ord	11	amod	11:amod	_
+10	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	11	amod	11:amod	_
 11	appearance	appearance	NOUN	NN	Number=Sing	8	obj	8:obj	_
 12	on	on	ADP	IN	_	14	case	14:case	_
 13	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
@@ -3805,7 +3805,7 @@
 6	of	of	ADP	IN	_	7	case	7:case	_
 7	Clinton	Clinton	PROPN	NNP	Number=Sing	5	nmod	5:nmod:of	_
 8	as	as	ADP	IN	_	10	case	10:case	_
-9	First	first	ADJ	JJ	Degree=Pos|NumType=Ord	10	compound	10:compound	_
+9	First	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	10	compound	10:compound	_
 10	Lady	lady	NOUN	NN	Number=Sing	7	nmod	7:nmod:as	_
 11	became	become	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	16	advcl	16:advcl:as	_
 12	more	more	ADV	RBR	_	13	advmod	13:advmod	_
@@ -4194,7 +4194,7 @@
 3	exhibited	exhibit	VERB	VBN	Tense=Past|VerbForm=Part	13	csubj	13:csubj	_
 4	for	for	ADP	IN	_	7	case	7:case	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
-6	first	first	ADJ	JJ	Degree=Pos|NumType=Ord	7	amod	7:amod	_
+6	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	7	amod	7:amod	_
 7	time	time	NOUN	NN	Number=Sing	3	obl	3:obl:for	_
 8	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	13	cop	13:cop	_
 9	British	British	PROPN	NNP	Number=Sing	10	compound	10:compound	Proper=True
@@ -9102,7 +9102,7 @@
 7	Athens	Athens	PROPN	NNP	Number=Sing	5	nmod	5:nmod:of	_
 8	in	in	ADP	IN	_	11	case	11:case	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
-10	5th	5th	ADJ	JJ	Degree=Pos|NumType=Ord	11	amod	11:amod	_
+10	5th	5th	ADJ	JJ	Degree=Pos|NumForm=Combi|NumType=Ord	11	amod	11:amod	_
 11	century	century	NOUN	NN	Number=Sing	5	nmod	5:nmod:in	_
 12	BC	bc	NOUN	NN	Number=Sing	11	nmod:npmod	11:nmod:npmod	SpaceAfter=No
 13	,	,	PUNCT	,	_	16	punct	16:punct	_
@@ -9243,7 +9243,7 @@
 4	founded	found	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4.1	founded	found	VERB	VBN	Tense=Past|VerbForm=Part	_	_	4:conj:and	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
-6	first	first	ADJ	JJ	Degree=Pos|NumType=Ord	8	amod	8:amod	_
+6	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	8	amod	8:amod	_
 7	film	film	NOUN	NN	Number=Sing	8	compound	8:compound	_
 8	company	company	NOUN	NN	Number=Sing	4	nsubj:pass	4:nsubj:pass|18:nsubj:pass	_
 9	(	(	PUNCT	-LRB-	_	11	punct	11:punct	SpaceAfter=No
@@ -9478,7 +9478,7 @@
 19	themselves	themselves	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	18	obj	18:obj	_
 20	in	in	ADP	IN	_	23	case	23:case	_
 21	the	the	DET	DT	Definite=Def|PronType=Art	23	det	23:det	_
-22	6th	6th	ADJ	JJ	Degree=Pos|NumType=Ord	23	amod	23:amod	_
+22	6th	6th	ADJ	JJ	Degree=Pos|NumForm=Combi|NumType=Ord	23	amod	23:amod	_
 23	century	century	NOUN	NN	Number=Sing	18	obl	18:obl:in	_
 24	AD	ad	NOUN	NN	Number=Sing	23	nmod:npmod	23:nmod:npmod	SpaceAfter=No
 25	.	.	PUNCT	.	_	9	punct	9:punct	_
@@ -9490,7 +9490,7 @@
 3	end	end	NOUN	NN	Number=Sing	12	obl	12:obl:at	_
 4	of	of	ADP	IN	_	7	case	7:case	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
-6	8th	8th	ADJ	JJ	Degree=Pos|NumType=Ord	7	amod	7:amod	_
+6	8th	8th	ADJ	JJ	Degree=Pos|NumForm=Combi|NumType=Ord	7	amod	7:amod	_
 7	century	century	NOUN	NN	Number=Sing	3	nmod	3:nmod:of	SpaceAfter=No
 8	,	,	PUNCT	,	_	12	punct	12:punct	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
@@ -9553,7 +9553,7 @@
 # sent_id = w01010047
 # text = Their first king was Mojmír I (ruled 830–846).
 1	Their	they	PRON	PRP$	Number=Plur|Person=3|Poss=Yes|PronType=Prs	3	nmod:poss	3:nmod:poss	_
-2	first	first	ADJ	JJ	Degree=Pos|NumType=Ord	3	amod	3:amod	_
+2	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	3	amod	3:amod	_
 3	king	king	NOUN	NN	Number=Sing	5	nsubj	5:nsubj	_
 4	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	cop	5:cop	_
 5	Mojmír	Mojmír	PROPN	NNP	Number=Sing	0	root	0:root	_
@@ -10553,7 +10553,7 @@
 # sent_id = w01028004
 # text = The first and foremost was the Ohio River, which flowed into the Mississippi River.
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
-2	first	first	ADJ	JJ	Degree=Pos|NumType=Ord	8	nsubj	8:nsubj	_
+2	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	8	nsubj	8:nsubj	_
 3	and	and	CCONJ	CC	_	4	cc	4:cc	_
 4	foremost	foremost	ADJ	JJ	Degree=Pos	2	conj	2:conj:and|8:nsubj	_
 5	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	cop	8:cop	_
@@ -11652,7 +11652,7 @@
 27	during	during	ADP	IN	_	31	case	31:case	_
 28	the	the	DET	DT	Definite=Def|PronType=Art	31	det	31:det	_
 29	late	late	ADJ	JJ	Degree=Pos	31	amod	31:amod	_
-30	15th	15th	ADJ	JJ	Degree=Pos|NumType=Ord	31	amod	31:amod	_
+30	15th	15th	ADJ	JJ	Degree=Pos|NumForm=Combi|NumType=Ord	31	amod	31:amod	_
 31	century	century	NOUN	NN	Number=Sing	23	nmod	23:nmod:during	SpaceAfter=No
 32	.	.	PUNCT	.	_	6	punct	6:punct	_
 
@@ -11708,7 +11708,7 @@
 # text = During the first century of development, Spanish dominance in the region remained undisputed.
 1	During	during	ADP	IN	_	4	case	4:case	_
 2	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
-3	first	first	ADJ	JJ	Degree=Pos|NumType=Ord	4	amod	4:amod	_
+3	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	4	amod	4:amod	_
 4	century	century	NOUN	NN	Number=Sing	13	obl	13:obl:during	_
 5	of	of	ADP	IN	_	6	case	6:case	_
 6	development	development	NOUN	NN	Number=Sing	4	nmod	4:nmod:of	SpaceAfter=No
@@ -11726,7 +11726,7 @@
 # text = From the 16th century, Europeans visiting the Caribbean region identified the "South Sea" (the Pacific Ocean, to the south of the isthmus of Panama) as opposed to the "North Sea" (the Caribbean Sea, to the north of the same isthmus).
 1	From	from	ADP	IN	_	4	case	4:case	_
 2	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
-3	16th	16th	ADJ	JJ	Degree=Pos|NumType=Ord	4	amod	4:amod	_
+3	16th	16th	ADJ	JJ	Degree=Pos|NumForm=Combi|NumType=Ord	4	amod	4:amod	_
 4	century	century	NOUN	NN	Number=Sing	11	obl	11:obl:from	SpaceAfter=No
 5	,	,	PUNCT	,	_	11	punct	11:punct	_
 6	Europeans	Europeans	PROPN	NNPS	Number=Plur	11	nsubj	11:nsubj	_
@@ -12057,7 +12057,7 @@
 13-14	world's	_	_	_	_	_	_	_	_
 13	world	world	NOUN	NN	Number=Sing	19	nmod:poss	19:nmod:poss	_
 14	's	's	PART	POS	_	13	case	13:case	_
-15	second	second	ADJ	JJ	Degree=Pos|NumType=Ord	19	amod	19:amod	_
+15	second	second	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	19	amod	19:amod	_
 16	officially	officially	ADV	RB	_	17	advmod	17:advmod	_
 17	established	establish	VERB	VBN	Tense=Past|VerbForm=Part	19	amod	19:amod	_
 18	national	national	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
@@ -12254,7 +12254,7 @@
 1	Indeed	indeed	ADV	RB	_	18	advmod	18:advmod	SpaceAfter=No
 2	,	,	PUNCT	,	_	18	punct	18:punct	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
-4	first	first	ADJ	JJ	Degree=Pos|NumType=Ord	6	amod	6:amod	_
+4	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	6	amod	6:amod	_
 5	scholarly	scholarly	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	report	report	NOUN	NN	Number=Sing	18	nsubj	18:nsubj	_
 7	on	on	ADP	IN	_	9	case	9:case	_
@@ -13075,7 +13075,7 @@
 6	dating	date	VERB	VBG	VerbForm=Ger	4	acl	4:acl	_
 7	from	from	ADP	IN	_	10	case	10:case	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
-9	14th	14th	ADJ	JJ	Degree=Pos|NumType=Ord	10	amod	10:amod	_
+9	14th	14th	ADJ	JJ	Degree=Pos|NumForm=Combi|NumType=Ord	10	amod	10:amod	_
 10	century	century	NOUN	NN	Number=Sing	6	obl	6:obl:from	_
 11	BCE	bce	NOUN	NN	Number=Sing	10	nmod:npmod	10:nmod:npmod	SpaceAfter=No
 12	,	,	PUNCT	,	_	6	punct	6:punct	_
@@ -13565,7 +13565,7 @@
 7	in	in	ADP	IN	_	8	case	8:case	_
 8	Yucatán	Yucatán	PROPN	NNP	Number=Sing	6	nmod	6:nmod:in	_
 9	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
-10	third	third	ADJ	JJ	Degree=Pos|NumType=Ord	11	amod	11:amod	_
+10	third	third	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	11	amod	11:amod	_
 11	system	system	NOUN	NN	Number=Sing	14	nsubj	14:nsubj	_
 12	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	cop	14:cop	_
 13	in	in	ADP	IN	_	14	case	14:case	_
@@ -13632,7 +13632,7 @@
 # text = During the first stages of Romanization, the peninsula was divided in two by the Romans for administrative purposes.
 1	During	during	ADP	IN	_	4	case	4:case	_
 2	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
-3	first	first	ADJ	JJ	Degree=Pos|NumType=Ord	4	amod	4:amod	_
+3	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	4	amod	4:amod	_
 4	stages	stage	NOUN	NNS	Number=Plur	11	obl	11:obl:during	_
 5	of	of	ADP	IN	_	6	case	6:case	_
 6	Romanization	Romanization	PROPN	NNP	Number=Sing	4	nmod	4:nmod:of	SpaceAfter=No
@@ -13655,7 +13655,7 @@
 # text = By the 3rd century the emperor Caracalla made a new division which lasted only a short time.
 1	By	by	ADP	IN	_	4	case	4:case	_
 2	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
-3	3rd	3rd	ADJ	JJ	Degree=Pos|NumType=Ord	4	amod	4:amod	_
+3	3rd	3rd	ADJ	JJ	Degree=Pos|NumForm=Combi|NumType=Ord	4	amod	4:amod	_
 4	century	century	NOUN	NN	Number=Sing	8	obl	8:obl:by	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	emperor	emperor	NOUN	NN	Number=Sing	8	nsubj	8:nsubj	_
@@ -13691,7 +13691,7 @@
 14	that	that	SCONJ	IN	_	22	mark	22:mark	_
 15	when	when	ADV	WRB	PronType=Int	20	advmod	20:advmod	_
 16	their	they	PRON	PRP$	Number=Plur|Person=3|Poss=Yes|PronType=Prs	18	nmod:poss	18:nmod:poss	_
-17	first	first	ADJ	JJ	Degree=Pos|NumType=Ord	18	amod	18:amod	_
+17	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	18	amod	18:amod	_
 18	child	child	NOUN	NN	Number=Sing	20	nsubj:pass	20:nsubj:pass	_
 19	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	20	aux:pass	20:aux:pass	_
 20	born	bear	VERB	VBN	Tense=Past|VerbForm=Part	22	advcl	22:advcl	_
@@ -14062,7 +14062,7 @@
 28	hand	hand	NOUN	NN	Number=Sing	25	obj	25:obj	_
 29	during	during	ADP	IN	_	33	case	33:case	_
 30	the	the	DET	DT	Definite=Def|PronType=Art	33	det	33:det	_
-31	first	first	ADJ	JJ	Degree=Pos|NumType=Ord	33	amod	33:amod	_
+31	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	33	amod	33:amod	_
 32	two	two	NUM	CD	NumForm=Word|NumType=Card	33	nummod	33:nummod	_
 33	years	year	NOUN	NNS	Number=Plur	25	obl	25:obl:during	_
 34	of	of	ADP	IN	_	36	case	36:case	_
@@ -14416,7 +14416,7 @@
 5	West	west	NOUN	NN	Number=Sing	2	nmod	2:nmod:with	_
 6	during	during	ADP	IN	_	9	case	9:case	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
-8	16th	16th	ADJ	JJ	Degree=Pos|NumType=Ord	9	amod	9:amod	_
+8	16th	16th	ADJ	JJ	Degree=Pos|NumForm=Combi|NumType=Ord	9	amod	9:amod	_
 9	century	century	NOUN	NN	Number=Sing	2	nmod	2:nmod:during	_
 10	lead	lead	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
 11	to	to	ADP	IN	_	13	case	13:case	_
@@ -14847,7 +14847,7 @@
 9	car	car	NOUN	NN	Number=Sing	4	obl	4:obl:as	_
 10	of	of	ADP	IN	_	13	case	13:case	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
-12	20th	20th	ADJ	JJ	Degree=Pos|NumType=Ord	13	amod	13:amod	_
+12	20th	20th	ADJ	JJ	Degree=Pos|NumForm=Combi|NumType=Ord	13	amod	13:amod	_
 13	century	century	NOUN	NN	Number=Sing	9	nmod	9:nmod:of	_
 14	in	in	ADP	IN	_	21	case	21:case	_
 15	the	the	DET	DT	Definite=Def|PronType=Art	21	det	21:det	_
@@ -15163,7 +15163,7 @@
 21	force	force	NOUN	NN	Number=Sing	17	obl	17:obl:as	_
 22	following	follow	VERB	VBG	VerbForm=Ger	27	case	27:case	_
 23	their	they	PRON	PRP$	Number=Plur|Person=3|Poss=Yes|PronType=Prs	27	nmod:poss	27:nmod:poss	_
-24	first	first	ADJ	JJ	Degree=Pos|NumType=Ord	27	amod	27:amod	SpaceAfter=No
+24	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	27	amod	27:amod	SpaceAfter=No
 25	,	,	PUNCT	,	_	27	punct	27:punct	_
 26	epic	epic	ADJ	JJ	Degree=Pos	27	amod	27:amod	_
 27	charge	charge	NOUN	NN	Number=Sing	17	obl	17:obl:following	SpaceAfter=No
@@ -16271,7 +16271,7 @@
 5	published	publish	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 6	of	of	ADP	IN	_	9	case	9:case	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
-8	first	first	ADJ	JJ	Degree=Pos|NumType=Ord	9	amod	9:amod	_
+8	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	9	amod	9:amod	_
 9	edition	edition	NOUN	NN	Number=Sing	3	nmod	3:nmod:of	SpaceAfter=No
 10	.	.	PUNCT	.	_	5	punct	5:punct	_
 
@@ -16428,7 +16428,7 @@
 8-9	Disney's	_	_	_	_	_	_	_	_
 8	Disney	Disney	PROPN	NNP	Number=Sing	12	nmod:poss	12:nmod:poss	_
 9	's	's	PART	POS	_	8	case	8:case	_
-10	first	first	ADJ	JJ	Degree=Pos|NumType=Ord	12	amod	12:amod	_
+10	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	12	amod	12:amod	_
 11	non-white	non-white	ADJ	JJ	Degree=Pos	12	amod	12:amod	_
 12	princess	princess	NOUN	NN	Number=Sing	7	xcomp	7:xcomp	_
 13	as	as	SCONJ	IN	_	19	mark	19:mark	_
@@ -17856,7 +17856,7 @@
 7	Plantagenet	Plantagenet	PROPN	NNP	Number=Sing	6	flat	6:flat	SpaceAfter=No
 8	,	,	PUNCT	,	_	11	punct	11:punct	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
-10	3rd	3rd	ADJ	JJ	Degree=Pos|NumType=Ord	11	amod	11:amod	Proper=True
+10	3rd	3rd	ADJ	JJ	Degree=Pos|NumForm=Combi|NumType=Ord	11	amod	11:amod	Proper=True
 11	Duke	Duke	PROPN	NNP	Number=Sing	6	appos	6:appos	_
 12	of	of	ADP	IN	_	13	case	13:case	Proper=True
 13	York	York	PROPN	NNP	Number=Sing	11	nmod	11:nmod:of	SpaceAfter=No
@@ -17974,7 +17974,7 @@
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	seek	seek	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 6	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
-7	third	third	ADJ	JJ	Degree=Pos|NumType=Ord	8	amod	8:amod	_
+7	third	third	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	8	amod	8:amod	_
 8	term	term	NOUN	NN	Number=Sing	5	obj	5:obj	_
 9	in	in	ADP	IN	_	13	case	13:case	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
@@ -18017,7 +18017,7 @@
 4	Senate	Senate	PROPN	NNP	Number=Sing	2	obj	2:obj	_
 5	for	for	ADP	IN	_	8	case	8:case	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
-7	first	first	ADJ	JJ	Degree=Pos|NumType=Ord	8	amod	8:amod	_
+7	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	8	amod	8:amod	_
 8	time	time	NOUN	NN	Number=Sing	2	obl	2:obl:for	_
 9	since	since	ADP	IN	_	10	case	10:case	_
 10	1952	1952	NUM	CD	NumForm=Digit|NumType=Card	8	nmod	8:nmod:since	SpaceAfter=No
@@ -18052,7 +18052,7 @@
 12	,	,	PUNCT	,	_	5	punct	5:punct	_
 13	becoming	become	VERB	VBG	VerbForm=Ger	2	advcl	2:advcl	_
 14	the	the	DET	DT	Definite=Def|PronType=Art	18	det	18:det	_
-15	first	first	ADJ	JJ	Degree=Pos|NumType=Ord	18	amod	18:amod	_
+15	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	18	amod	18:amod	_
 16	serving	serve	VERB	VBG	VerbForm=Ger	18	amod	18:amod	_
 17	U.S.	U.S.	PROPN	NNP	Number=Sing	18	compound	18:compound	_
 18	president	president	NOUN	NN	Number=Sing	13	xcomp	13:xcomp	_
@@ -18217,7 +18217,7 @@
 11	about	about	ADP	IN	_	16	case	16:case	_
 12	her	she	PRON	PRP$	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	16	nmod:poss	16:nmod:poss	_
 13	upcoming	upcoming	ADJ	JJ	Degree=Pos	16	amod	16:amod	_
-14	third	third	ADJ	JJ	Degree=Pos|NumType=Ord	16	amod	16:amod	_
+14	third	third	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	16	amod	16:amod	_
 15	studio	studio	NOUN	NN	Number=Sing	16	compound	16:compound	_
 16	album	album	NOUN	NN	Number=Sing	10	nmod	10:nmod:about	SpaceAfter=No
 17	.	.	PUNCT	.	_	8	punct	8:punct	_
@@ -19130,7 +19130,7 @@
 14	lost	lose	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
 15	for	for	ADP	IN	_	18	case	18:case	_
 16	the	the	DET	DT	Definite=Def|PronType=Art	18	det	18:det	_
-17	first	first	ADJ	JJ	Degree=Pos|NumType=Ord	18	amod	18:amod	_
+17	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	18	amod	18:amod	_
 18	time	time	NOUN	NN	Number=Sing	14	obl	14:obl:for	_
 19	in	in	ADP	IN	_	22	case	22:case	_
 20	the	the	DET	DT	Definite=Def|PronType=Art	22	det	22:det	_
@@ -19789,7 +19789,7 @@
 9	could	could	AUX	MD	VerbForm=Fin	10	aux	10:aux	_
 10	elect	elect	VERB	VB	VerbForm=Inf	0	root	0:root	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
-12	first	first	ADJ	JJ	Degree=Pos|NumType=Ord	14	amod	14:amod	_
+12	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	14	amod	14:amod	_
 13	female	female	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
 14	president	president	NOUN	NN	Number=Sing	10	obj	10:obj	_
 15	in	in	ADP	IN	_	17	case	17:case	_
@@ -19847,7 +19847,7 @@
 # sent_id = n03003036
 # text = A third-party majority is needed, specifically the votes of 367 MPs (out of 550), whereas 330 votes are required in order to trigger a referendum.
 1	A	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
-2	third	third	ADJ	JJ	Degree=Pos|NumType=Ord	4	amod	4:amod	SpaceAfter=No
+2	third	third	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	4	amod	4:amod	SpaceAfter=No
 3	-	-	PUNCT	HYPH	_	4	punct	4:punct	SpaceAfter=No
 4	party	party	NOUN	NN	Number=Sing	5	compound	5:compound	_
 5	majority	majority	NOUN	NN	Number=Sing	7	nsubj:pass	7:nsubj:pass	_
@@ -20178,7 +20178,7 @@
 4	undertaken	undertake	VERB	VBN	Tense=Past|VerbForm=Part	3	acl	3:acl	_
 5	in	in	ADP	IN	_	8	case	8:case	_
 6	this	this	DET	DT	Number=Sing|PronType=Dem	8	det	8:det	_
-7	first	first	ADJ	JJ	Degree=Pos|NumType=Ord	8	amod	8:amod	_
+7	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	8	amod	8:amod	_
 8	hour	hour	NOUN	NN	Number=Sing	4	obl	4:obl:in	_
 9	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	cop	13:cop	_
 10	more	more	ADV	RBR	_	13	advmod	13:advmod	_
@@ -20868,7 +20868,7 @@
 2	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	become	become	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
-5	fourth	fourth	ADJ	JJ	Degree=Pos|NumType=Ord	7	amod	7:amod	_
+5	fourth	fourth	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	7	amod	7:amod	_
 6	American	American	ADJ	JJ	Degree=Pos	7	amod	7:amod	Proper=True
 7	company	company	NOUN	NN	Number=Sing	3	xcomp	3:xcomp	_
 8	with	with	ADP	IN	_	12	case	12:case	_
@@ -20972,7 +20972,7 @@
 # text = For the first time in the last six years the rate of unemployment has dropped below 20%, and there are already 600,000 more people employed than there were a year ago.
 1	For	for	ADP	IN	_	4	case	4:case	_
 2	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
-3	first	first	ADJ	JJ	Degree=Pos|NumType=Ord	4	amod	4:amod	_
+3	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	4	amod	4:amod	_
 4	time	time	NOUN	NN	Number=Sing	15	obl	15:obl:for	_
 5	in	in	ADP	IN	_	9	case	9:case	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
@@ -21634,7 +21634,7 @@
 22	end	end	NOUN	NN	Number=Sing	17	obl	17:obl:by	_
 23	of	of	ADP	IN	_	27	case	27:case	_
 24	the	the	DET	DT	Definite=Def|PronType=Art	27	det	27:det	_
-25	Second	second	ADJ	JJ	Degree=Pos|NumType=Ord	27	amod	27:amod	Proper=True
+25	Second	second	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	27	amod	27:amod	Proper=True
 26	World	world	PROPN	NN	Number=Sing	27	compound	27:compound	_
 27	War	war	PROPN	NN	Number=Sing	22	nmod	22:nmod:of	SpaceAfter=No
 28	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -21722,7 +21722,7 @@
 7	originates	originate	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 8	from	from	ADP	IN	_	11	case	11:case	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
-10	13th	13th	ADJ	JJ	Degree=Pos|NumType=Ord	11	amod	11:amod	_
+10	13th	13th	ADJ	JJ	Degree=Pos|NumForm=Combi|NumType=Ord	11	amod	11:amod	_
 11	century	century	NOUN	NN	Number=Sing	7	obl	7:obl:from	_
 12	and	and	CCONJ	CC	_	14	cc	14:cc	_
 13	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	aux:pass	14:aux:pass	_
@@ -22012,7 +22012,7 @@
 14	to	to	ADP	IN	_	18	case	18:case	_
 15	the	the	DET	DT	Definite=Def|PronType=Art	18	det	18:det	_
 16	early	early	ADJ	JJ	Degree=Pos	18	amod	18:amod	_
-17	5th	5th	ADJ	JJ	Degree=Pos|NumType=Ord	18	amod	18:amod	_
+17	5th	5th	ADJ	JJ	Degree=Pos|NumForm=Combi|NumType=Ord	18	amod	18:amod	_
 18	century	century	NOUN	NN	Number=Sing	12	obl	12:obl:to	_
 19	BC	bc	ADV	RB	_	18	nmod:tmod	18:nmod:tmod	SpaceAfter=No
 20	.	.	PUNCT	.	_	12	punct	12:punct	_
@@ -22167,7 +22167,7 @@
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
 2	declare	declare	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
-4	first	first	ADJ	JJ	Degree=Pos|NumType=Ord	7	amod	7:amod	_
+4	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	7	amod	7:amod	_
 5	international	international	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 6	Olympic	olympic	ADJ	JJ	Degree=Pos	7	amod	7:amod	Proper=True
 7	games	game	NOUN	NNS	Number=Plur	2	obj	2:obj|8:nsubj:xsubj	_
@@ -22178,7 +22178,7 @@
 # sent_id = w02012042
 # text = The First World War brought about shifts and new developments in colonial politics.
 1	The	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
-2	First	first	ADJ	JJ	Degree=Pos|NumType=Ord	4	amod	4:amod	_
+2	First	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	4	amod	4:amod	_
 3	World	world	PROPN	NN	Number=Sing	4	compound	4:compound	_
 4	War	war	PROPN	NN	Number=Sing	5	nsubj	5:nsubj	_
 5	brought	bring	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
@@ -22470,7 +22470,7 @@
 22	of	of	SCONJ	IN	_	23	mark	23:mark	_
 23	winning	win	VERB	VBG	VerbForm=Ger	21	acl	21:acl:of	_
 24	his	he	PRON	PRP$	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	27	nmod:poss	27:nmod:poss	_
-25	second	second	ADJ	JJ	Degree=Pos|NumType=Ord	27	amod	27:amod	_
+25	second	second	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	27	amod	27:amod	_
 26	gold	gold	NOUN	NN	Number=Sing	27	compound	27:compound	_
 27	medal	medal	NOUN	NN	Number=Sing	23	obj	23:obj	SpaceAfter=No
 28	.	.	PUNCT	.	_	19	punct	19:punct	_
@@ -22817,7 +22817,7 @@
 # text = In the 8th century BC, Greece began to emerge from the Dark Ages which followed the fall of the Mycenaean civilization.
 1	In	in	ADP	IN	_	4	case	4:case	_
 2	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
-3	8th	8th	ADJ	JJ	Degree=Pos|NumType=Ord	4	amod	4:amod	_
+3	8th	8th	ADJ	JJ	Degree=Pos|NumForm=Combi|NumType=Ord	4	amod	4:amod	_
 4	century	century	NOUN	NN	Number=Sing	8	obl	8:obl:in	_
 5	BC	bc	NOUN	RB	_	4	nmod:tmod	4:nmod:tmod	SpaceAfter=No
 6	,	,	PUNCT	,	_	8	punct	8:punct	_
@@ -22871,12 +22871,12 @@
 # text = From the 9th century BC, the first Greek texts began to appear.
 1	From	from	ADP	IN	_	4	case	4:case	_
 2	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
-3	9th	9th	ADJ	JJ	Degree=Pos|NumType=Ord	4	amod	4:amod	_
+3	9th	9th	ADJ	JJ	Degree=Pos|NumForm=Combi|NumType=Ord	4	amod	4:amod	_
 4	century	century	NOUN	NN	Number=Sing	11	obl	11:obl:from	_
 5	BC	BC	NOUN	NNP	Number=Sing	4	nmod:tmod	4:nmod:tmod	SpaceAfter=No
 6	,	,	PUNCT	,	_	11	punct	11:punct	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
-8	first	first	ADJ	JJ	Degree=Pos|NumType=Ord	10	amod	10:amod	_
+8	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	10	amod	10:amod	_
 9	Greek	Greek	ADJ	JJ	Degree=Pos	10	amod	10:amod	Proper=True
 10	texts	text	NOUN	NNS	Number=Plur	11	nsubj	11:nsubj|13:nsubj:xsubj	_
 11	began	begin	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
@@ -22931,7 +22931,7 @@
 1	From	from	ADP	IN	_	5	case	5:case	_
 2	about	about	ADV	IN	_	4	advmod	4:advmod	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
-4	8th	8th	ADJ	JJ	Degree=Pos|NumType=Ord	5	amod	5:amod	_
+4	8th	8th	ADJ	JJ	Degree=Pos|NumForm=Combi|NumType=Ord	5	amod	5:amod	_
 5	century	century	NOUN	NN	Number=Sing	9	obl	9:obl:from	_
 6	BC	bc	NOUN	NN	Number=Sing	5	nmod:tmod	5:nmod:tmod	_
 7	city	city	NOUN	NN	Number=Sing	8	compound	8:compound	_
@@ -23528,7 +23528,7 @@
 # sent_id = w04004051
 # text = The second Apulian and Calabrian Royal Region was then established, also including Samnium, parts of Molise and the oriental Basilicata.
 1	The	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
-2	second	second	ADJ	JJ	Degree=Pos|NumType=Ord	7	amod	7:amod	_
+2	second	second	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	7	amod	7:amod	_
 3	Apulian	Apulian	PROPN	NNP	Number=Sing	7	compound	7:compound	_
 4	and	and	CCONJ	CC	_	5	cc	5:cc	_
 5	Calabrian	Calabrian	PROPN	NNP	Number=Sing	3	conj	3:conj:and|7:compound	_
@@ -23683,7 +23683,7 @@
 23	up	up	ADP	RP	_	21	compound:prt	21:compound:prt	_
 24	for	for	ADP	IN	_	27	case	27:case	_
 25	the	the	DET	DT	Definite=Def|PronType=Art	27	det	27:det	_
-26	second	second	ADJ	JJ	Degree=Pos|NumType=Ord	27	amod	27:amod	_
+26	second	second	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	27	amod	27:amod	_
 27	time	time	NOUN	NN	Number=Sing	21	obl	21:obl:for	SpaceAfter=No
 28	.	.	PUNCT	.	_	17	punct	17:punct	_
 
@@ -23971,7 +23971,7 @@
 # text = In the 20th century, between 1904 and 1914, Antonio Gaudí brought about a reform that lasted ten years.
 1	In	in	ADP	IN	_	4	case	4:case	_
 2	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
-3	20th	20th	ADJ	JJ	Degree=Pos|NumType=Ord	4	amod	4:amod	_
+3	20th	20th	ADJ	JJ	Degree=Pos|NumForm=Combi|NumType=Ord	4	amod	4:amod	_
 4	century	century	NOUN	NN	Number=Sing	13	obl	13:obl:in	SpaceAfter=No
 5	,	,	PUNCT	,	_	13	punct	13:punct	_
 6	between	between	ADP	IN	_	7	case	7:case	_
@@ -24187,7 +24187,7 @@
 4	portion	portion	NOUN	NN	Number=Sing	0	root	0:root	_
 5	from	from	ADP	IN	_	8	case	8:case	_
 6	this	this	DET	DT	Number=Sing|PronType=Dem	8	det	8:det	_
-7	second	second	ADJ	JJ	Degree=Pos|NumType=Ord	8	amod	8:amod	_
+7	second	second	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	8	amod	8:amod	_
 8	boundary	boundary	NOUN	NN	Number=Sing	4	nmod	4:nmod:from	_
 9	up	up	ADP	RB	_	13	case	13:case	_
 10	to	to	ADP	IN	_	9	fixed	9:fixed	_
@@ -24693,7 +24693,7 @@
 # text = On the 1st January 49 BC, Marco Antonio read a declaration from Caesar in which the proconsul declared himself a friend of peace.
 1	On	on	ADP	IN	_	4	case	4:case	_
 2	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
-3	1st	1st	ADJ	JJ	Degree=Pos|NumType=Ord	4	amod	4:amod	_
+3	1st	1st	ADJ	JJ	Degree=Pos|NumForm=Combi|NumType=Ord	4	amod	4:amod	_
 4	January	January	PROPN	NNP	Number=Sing	10	obl	10:obl:on	_
 5	49	49	NUM	CD	NumForm=Digit|NumType=Card	4	nummod	4:nummod	_
 6	BC	bc	NOUN	NN	Number=Sing	4	nmod:npmod	4:nmod:npmod	SpaceAfter=No


### PR DESCRIPTION
Addresses https://github.com/UniversalDependencies/UD_English-PUD/issues/28

Done with the following Ssurgeon script, although it relies on a couple unreleased features:

```
# being lazy: first update everything to Combi,
# then update the letter only ones to Word
{word:/^[0-9a-zA-Z]+$/;morphofeatures:/^.*NumType=Ord.*$/}=number
EditNode -node number -updateMorphoFeatures NumForm=Combi

{word:/^[a-zA-Z]+$/;morphofeatures:/^.*NumType=Ord.*$/}=number
EditNode -node number -updateMorphoFeatures NumForm=Word
```