### PR TITLE
Fix a few remaining nmod:desc

### DIFF
--- a/en_pud-ud-test.conllu
+++ b/en_pud-ud-test.conllu
@@ -10399,9 +10399,9 @@
 21	impregnable	impregnable	ADJ	JJ	Degree=Pos	16	xcomp	16:xcomp	SpaceAfter=No
 22	,	,	PUNCT	,	_	29	punct	29:punct	_
 23	and	and	CCONJ	CC	_	29	cc	29:cc	_
-24	General	general	NOUN	NN	Number=Sing	29	nsubj:pass	29:nsubj:pass	_
-25	de	de	PROPN	NNP	Number=Sing	24	flat	24:flat	_
-26	Meza	Meza	PROPN	NNP	Number=Sing	24	flat	24:flat	_
+24	General	general	NOUN	NN	Number=Sing	25	nmod:desc	25:nmod:desc	_
+25	de	de	PROPN	NNP	Number=Sing	29	nsubj:pass	29:nsubj:pass	_
+26	Meza	Meza	PROPN	NNP	Number=Sing	25	flat	25:flat	_
 27	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	29	aux:pass	29:aux:pass	_
 28	promptly	promptly	ADV	RB	_	29	advmod	29:advmod	_
 29	relieved	relieved	ADJ	JJ	Degree=Pos	5	conj	5:conj:and	_
@@ -17389,10 +17389,10 @@
 12	Muppets	Muppets	PROPN	NNPS	Number=Plur	7	obl	7:obl:in	SpaceAfter=No
 13	,	,	PUNCT	,	_	7	punct	7:punct	_
 14	as	as	ADP	IN	_	18	case	18:case	_
-15	Miss	Miss	PROPN	NNP	Number=Sing	18	nmod:poss	18:nmod:poss	_
+15	Miss	Miss	PROPN	NNP	Number=Sing	16	nmod:desc	16:nmod:desc	_
 16-17	Piggy's	_	_	_	_	_	_	_	_
-16	Piggy	Piggy	PROPN	NNP	Number=Sing	15	flat	15:flat	_
-17	's	's	PART	POS	_	15	case	15:case	_
+16	Piggy	Piggy	PROPN	NNP	Number=Sing	18	nmod:poss	18:nmod:poss	_
+17	's	's	PART	POS	_	16	case	16:case	_
 18	receptionist	receptionist	NOUN	NN	Number=Sing	7	obl	7:obl:as	SpaceAfter=No
 19	.	.	PUNCT	.	_	7	punct	7:punct	_
 
@@ -21903,8 +21903,8 @@
 5	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 6	Turkish	Turkish	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 7	Minister	minister	NOUN	NN	Number=Sing	10	nsubj	10:nsubj	_
-8	President	President	PROPN	NNP	Number=Sing	7	appos	7:appos	_
-9	Erdogan	Erdogan	PROPN	NNP	Number=Sing	8	flat	8:flat	_
+8	President	President	PROPN	NNP	Number=Sing	8	nmod:desc	8:nmod:desc	_
+9	Erdogan	Erdogan	PROPN	NNP	Number=Sing	7	appos	7:appos	_
 10	announced	announce	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
 11	his	his	PRON	PRP$	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	12	nmod:poss	12:nmod:poss	_
 12-13	government's	_	_	_	_	_	_	_	_
@@ -22749,7 +22749,7 @@
 12	,	,	PUNCT	,	_	11	punct	11:punct	_
 13	captained	captain	VERB	VBN	Tense=Past|VerbForm=Part	11	acl	11:acl	_
 14	by	by	ADP	IN	_	17	case	17:case	_
-15	Sir	Sir	PROPN	NNP	Number=Sing	17	compound	17:compound	_
+15	Sir	Sir	PROPN	NNP	Number=Sing	16	nmod:desc	16:nmod:desc	_
 16	Ernest	Ernest	PROPN	NNP	Number=Sing	13	obl	13:obl	_
 17	Shackleton	Shackleton	PROPN	NNP	Number=Sing	16	flat	16:flat	SpaceAfter=No
 18	,	,	PUNCT	,	_	11	punct	11:punct	_
@@ -23751,8 +23751,8 @@
 27	British	British	ADJ	JJ	Degree=Pos	29	amod	29:amod	_
 28	Prime	Prime	PROPN	NNP	Number=Sing	29	compound	29:compound	_
 29	Minister	Minister	PROPN	NNP	Number=Sing	32	nsubj	32:nsubj	_
-30	Lord	Lord	PROPN	NNP	Number=Sing	29	appos	29:appos	_
-31	Grenville	Grenville	PROPN	NNP	Number=Sing	30	flat	30:flat	_
+30	Lord	Lord	PROPN	NNP	Number=Sing	31	nmod:desc	31:nmod:desc	_
+31	Grenville	Grenville	PROPN	NNP	Number=Sing	29	appos	29:appos	_
 32	refused	refuse	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	parataxis	3:parataxis	_
 33	any	any	DET	DT	PronType=Ind	34	det	34:det	_
 34	agreement	agreement	NOUN	NN	Number=Sing	32	obj	32:obj	SpaceAfter=No
@@ -23760,7 +23760,7 @@
 36	and	and	CCONJ	CC	_	38	cc	38:cc	_
 37	so	so	ADV	RB	_	38	advmod	38:advmod	_
 38	did	do	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	32	conj	32:conj:and	_
-39	Tsar	Tsar	PROPN	NNP	Number=Sing	40	nsubj	40:nsubj	_
+39	Tsar	Tsar	PROPN	NNP	Number=Sing	40	nmod:desc	40:nmod:desc	_
 40	Alexander	Alexander	PROPN	NNP	Number=Sing	38	nsubj	38:nsubj	SpaceAfter=No
 41	.	.	PUNCT	.	_	3	punct	3:punct	_
 


### PR DESCRIPTION
@nschneid 

I found a few (using @martinpopel 's list) that I had missed in previous sweeps through this file

Also thought of a couple others which probably need editing:

`Sir Ernest Shackleton` - `Sir` counts, right?  Currently it's

```
13      captained       captain VERB    VBN     Tense=Past|VerbForm=Part        11      acl     11:acl  _
14      by      by      ADP     IN      _       17      case    17:case _
15      Sir     Sir     PROPN   NNP     Number=Sing     17      compound        17:compound     _
16      Ernest  Ernest  PROPN   NNP     Number=Sing     13      obl     13:obl  _
17      Shackleton      Shackleton      PROPN   NNP     Number=Sing     16      flat    16:flat SpaceAfter=No
```

and then, in this phrase

```
5       the     the     DET     DT      Definite=Def|PronType=Art       7       det     7:det   _
6       Turkish Turkish ADJ     JJ      Degree=Pos      7       amod    7:amod  _
7       Minister        minister        NOUN    NN      Number=Sing     10      nsubj   10:nsubj        _
8       President       President       PROPN   NNP     Number=Sing     7       appos   7:appos _
9       Erdogan Erdogan PROPN   NNP     Number=Sing     8       flat    8:flat  _
10      announced       announce        VERB    VBD     Mood=Ind|Tense=Past|VerbForm=Fin        0       root    0:root  _
```

I think `President Erdogan` maybe gets treated as a separate phrase from `the Turkish Minster`, and therefore `President` should also be `nmod:desc`.  Sound good?